### PR TITLE
Remove .rubocop.yml from attributes directory

### DIFF
--- a/attributes/.rubocop.yml
+++ b/attributes/.rubocop.yml
@@ -1,5 +1,0 @@
-inherit_from:
-  - ../.rubocop.yml
-
-LineLength:
-  Max: 150


### PR DESCRIPTION
Fixes chef/chef#6281.